### PR TITLE
Do not generate random parts that exceet 8bit values

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -106,7 +106,7 @@ class Helper {
 			mt_rand(0, 64) + 128,       // 8 bits  for "clock_seq_hi", with
 			// the most significant 2 bits being 10,
 			// required by version 4 GUIDs.
-			mt_rand(0, 256),            // 8 bits  for "clock_seq_low"
+			mt_rand(0, 255),            // 8 bits  for "clock_seq_low"
 			mt_rand(0, 65535),          // 16 bits for "node 0" and "node 1"
 			mt_rand(0, 65535),          // 16 bits for "node 2" and "node 3"
 			mt_rand(0, 65535)           // 16 bits for "node 4" and "node 5"


### PR DESCRIPTION
256 is one to much and will lead to 0x100 and therefore take 3 bytes instead of the expected 2