### PR TITLE
Quick fix for ampersand path error

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -73,7 +73,7 @@ const NewFilePlugin = {
 		const isPublic = document.getElementById('isPublic') ? document.getElementById('isPublic').value === '1' : false
 		if (isPublic) {
 			return window.FileList.createFile(filename).then(function() {
-				OCA.Viewer.open(path)
+				OCA.Viewer.open(path.replace(/&/g, '%26'))
 			})
 		}
 

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -112,6 +112,7 @@ export default {
 			const sharingToken = document.getElementById('sharingToken')
 			const dir = document.getElementById('dir')
 			let documentUrl = ''
+			this.filename = this.filename.replace(/&/g, '%26')
 			if (sharingToken && dir.value === '') {
 				documentUrl = getDocumentUrlForPublicFile(this.filename)
 			} else if (sharingToken) {


### PR DESCRIPTION
* Resolves: #58 
* Target version: master 

### Summary
Add a quick fix for broken URLs created when a file has an ampersand in the path. I'm sure there's a better way to get this fixed, but I wanted to post this in case it's useful to anyone.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
