### PR TITLE
Set UI language parameter in the backend

### DIFF
--- a/tests/lib/WOPI/ParserTest.php
+++ b/tests/lib/WOPI/ParserTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Officeonline\WOPI;
+
+use OCA\Officeonline\WOPI\DiscoveryManager;
+use OCA\Officeonline\WOPI\Parser;
+use OCP\IL10N;
+use OCP\IRequest;
+
+class ParserTest extends \Test\TestCase {
+	public function dataLanguage() {
+		return [
+			['de', 'de_DE', 'de-DE'],
+			['foo', 'de_DE', 'en-US'],
+			['en', 'en_US', 'en-US'],
+			['en', 'en_GB', 'en-gb'],
+			['en', 'de_DE', 'en-gb'],
+			['fr', 'fr_FR', 'fr-FR'],
+			['fr', 'fr_CA', 'fr-ca'],
+		];
+	}
+
+	/** @dataProvider dataLanguage */
+	public function testLanguage($language, $locale, $expected) {
+		$l10n = $this->createMock(IL10N::class);
+		$parser = new Parser(
+			$this->createMock(DiscoveryManager::class),
+			$this->createMock(IRequest::class),
+			$l10n
+		);
+
+		$l10n->expects($this->once())
+			->method('getLanguageCode')
+			->willReturn($language);
+		$l10n->expects($this->once())
+			->method('getLocaleCode')
+			->willReturn($locale);
+
+		self::assertEquals($expected, self::invokePrivate($parser, 'getLanguageCode'));
+	}
+}


### PR DESCRIPTION
Set the UI language parameter when opening files

This will ensure that the UI_LLCC parameter is properly replaced as defined in the WOPI docs 

https://wopi.readthedocs.io/en/latest/discovery.html?highlight=UI_LLCC#wopi-discovery-actions