### PR TITLE
Use new viewer syntax with destructuring object

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -73,7 +73,7 @@ const NewFilePlugin = {
 		const isPublic = document.getElementById('isPublic') ? document.getElementById('isPublic').value === '1' : false
 		if (isPublic) {
 			return window.FileList.createFile(filename).then(function() {
-				OCA.Viewer.open(path)
+				OCA.Viewer.open({ path })
 			})
 		}
 
@@ -81,7 +81,7 @@ const NewFilePlugin = {
 			console.debug(data)
 			if (data && data.status === 'success') {
 				window.FileList.add(data.data, { animate: true, scrollTo: true })
-				window.OCA.Viewer.open(path)
+				window.OCA.Viewer.open({ path })
 			} else {
 				window.OC.dialogs.alert(data.data.message, t('core', 'Could not create file'))
 			}


### PR DESCRIPTION
* Target version: master 

### Summary

With https://github.com/nextcloud/viewer/pull/936 and Nextcloud 22 the old syntax will not be supported anymore.


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
