### PR TITLE
fix: enforce view mode on mobile

### DIFF
--- a/lib/WOPI/Parser.php
+++ b/lib/WOPI/Parser.php
@@ -182,6 +182,11 @@ class Parser {
 			'internal-' . $fallbackProtocol,
 		];
 
+		$userAgent = $_SERVER["HTTP_USER_AGENT"];
+		if (preg_match("/(android|mobile)/i", $userAgent)) {
+			$edit = false;
+		}
+
 		$actions = [
 			$edit && $file->getSize() === 0 ? self::ACTION_EDITNEW : null,
 			$edit ? self::ACTION_EDIT : null,


### PR DESCRIPTION
Office online only supports view mode on mobile so we should limit that as it might fail to load otherwise on some setups.