### PR TITLE
fix: Do not always assume en-US as language if we cannot clearly determine

### DIFF
--- a/lib/WOPI/Parser.php
+++ b/lib/WOPI/Parser.php
@@ -269,6 +269,8 @@ class Parser {
 			return array_shift($languageMatches);
 		}
 
-		return 'en-US';
+		// Try to provide the language code matching RFC1766 format, if no language can be determined office will fallback to the browser language and then to en-US
+		// https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/online/discovery#ui_llcc
+		return str_replace('_', '-', $languageCode);
 	}
 }

--- a/tests/lib/WOPI/ParserTest.php
+++ b/tests/lib/WOPI/ParserTest.php
@@ -13,12 +13,17 @@ class ParserTest extends \Test\TestCase {
 	public function dataLanguage() {
 		return [
 			['de', 'de_DE', 'de-DE'],
-			['foo', 'de_DE', 'en-US'],
+			['foo', 'de_DE', 'foo'],
 			['en', 'en_US', 'en-US'],
 			['en', 'en_GB', 'en-gb'],
 			['en', 'de_DE', 'en-gb'],
 			['fr', 'fr_FR', 'fr-FR'],
 			['fr', 'fr_CA', 'fr-ca'],
+			['zh_CN', 'zh_CN', 'zh-CN'],
+			['zh_TW', 'zh_TW', 'zh-TW'],
+			['zh_CN', 'zh_Hans_CN', 'zh-CN'],
+			['zh_CN', 'zh_Hans_CN', 'zh-CN'],
+			['es_UY', 'es_UY', 'es-UY'],
 		];
 	}
 


### PR DESCRIPTION
Fix #100 

Previously we try to match our language/locale setting to a predefined list, but with some like zh_CN we didn't find the supported zh-CN.

The office documentation points that any value can be passed over:

https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/online/discovery#ui_llcc

> In addition to the values provided in the Locale ID column, you can supply any language, provided it's in the format described in RFC 1766. If you don't set a value for this placeholder, Office for the web tries to use the browser language setting (navigator.language). If no valid language can be determined, Office for the web defaults to en-US (US English).