### PR TITLE
fix: Skip CSP setup on CLI

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -123,6 +123,10 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function updateCSP() {
+		if (\OC::$CLI) {
+			return;
+		}
+
 		$container = $this->getContainer();
 
 		$publicWopiUrl = \OC::$server->getConfig()->getAppValue('officeonline', 'wopi_url');


### PR DESCRIPTION
Avoid throwing errors when building CSP on cron job exection where this is not needed