### PR TITLE
Fixed remote redirect URL for federation shared files

### DIFF
--- a/lib/Service/FederationService.php
+++ b/lib/Service/FederationService.php
@@ -139,7 +139,7 @@ class FederationService {
 				} else {
 					$wopi = $this->tokenManager->getRemoteTokenFromDirect($item, $direct->getUid());
 				}
-				$url = $remote . 'index.php/apps/officeonline/remote?shareToken=' . $item->getStorage()->getToken() .
+				$url = $remote . '/apps/officeonline/remote?shareToken=' . $item->getStorage()->getToken() .
 					'&remoteServer=' . $wopi->getServerHost() .
 					'&remoteServerToken=' . $wopi->getToken();
 				if ($item->getInternalPath() !== '') {

--- a/lib/Service/FederationService.php
+++ b/lib/Service/FederationService.php
@@ -139,7 +139,8 @@ class FederationService {
 				} else {
 					$wopi = $this->tokenManager->getRemoteTokenFromDirect($item, $direct->getUid());
 				}
-				$url = $remote . '/apps/officeonline/remote?shareToken=' . $item->getStorage()->getToken() .
+
+				$url = rtrim($remote, '/') . '/index.php/apps/officeonline/remote?shareToken=' . $item->getStorage()->getToken() .
 					'&remoteServer=' . $wopi->getServerHost() .
 					'&remoteServerToken=' . $wopi->getToken();
 				if ($item->getInternalPath() !== '') {


### PR DESCRIPTION
### Summary
Fixed remote redirect URL for federation shared files

### Use case:
After the file has been shared through the federation, it cannot be opened because the redirect URL is incorrect.

Example of a redirect URL:
it was:
`https://domain.comindex.php/apps/officeonline/remote?shareToken =...`
It became:
`https://domain.com/apps/officeonline/remote?shareToken =...`

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
