### PR TITLE
fix: Load public share link file creation again

### DIFF
--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ "8.0", "8.1", "8.2" ]
+        php-versions: [ "8.1", "8.2" ]
 
     name: php-lint
 

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -38,7 +38,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2']
+        php-versions: ['8.1', '8.2']
         server-versions: ['master', 'stable29', 'stable28']
 
     services:

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -38,7 +38,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0']
+        php-versions: ['8.1']
         server-versions: ['master']
 
     services:

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -38,7 +38,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0']
+        php-versions: ['8.1']
         server-versions: ['master']
 
     services:

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -38,7 +38,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0']
+        php-versions: ['8.1']
         server-versions: ['master']
 
     steps:

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -27,11 +27,10 @@ namespace OCA\Officeonline\AppInfo;
 use OC\Files\Type\Detection;
 use OC\Security\CSP\ContentSecurityPolicy;
 use OCA\Federation\TrustedServers;
-use OCA\Files\Event\LoadAdditionalScriptsEvent;
-use OCA\Files_Sharing\Listener\LoadAdditionalListener;
+use OCA\Files_Sharing\Event\BeforeTemplateRenderedEvent;
 use OCA\Officeonline\Capabilities;
 use OCA\Officeonline\Hooks\WopiLockHooks;
-use OCA\Officeonline\Listener\FilesScriptListener;
+use OCA\Officeonline\Listener\SharingLoadAdditionalScriptsListener;
 use OCA\Officeonline\Listener\LoadViewerListener;
 use OCA\Officeonline\Middleware\WOPIMiddleware;
 use OCA\Officeonline\PermissionManager;
@@ -63,8 +62,7 @@ class Application extends App implements IBootstrap {
 	public function register(IRegistrationContext $context): void {
 		$context->registerCapability(Capabilities::class);
 		$context->registerMiddleWare(WOPIMiddleware::class);
-		$context->registerEventListener(LoadAdditionalScriptsEvent::class, FilesScriptListener::class);
-		$context->registerEventListener(LoadAdditionalListener::class, FilesScriptListener::class);
+		$context->registerEventListener(BeforeTemplateRenderedEvent::class, SharingLoadAdditionalScriptsListener::class);
 		$context->registerEventListener(LoadViewer::class, LoadViewerListener::class);
 	}
 

--- a/src/document.js
+++ b/src/document.js
@@ -283,7 +283,7 @@ const documentsMain = {
 				}, 45000)
 			})
 
-			$('#loleafletframe').load(function() {
+			$('#loleafletframe').on('load', function() {
 				const ViewerToLool = [
 					'Action_FollowUser',
 					'Host_VersionRestore',

--- a/src/files.js
+++ b/src/files.js
@@ -1,3 +1,5 @@
+import Types from './helpers/types'
+import axios from '@nextcloud/axios'
 import { getCapabilities } from '@nextcloud/capabilities'
 import './viewer.js'
 import Vue from 'vue'
@@ -16,6 +18,77 @@ Vue.prototype.n = window.n
 Vue.prototype.OC = window.OC
 Vue.prototype.OCA = window.OCA
 
+const NewFilePlugin = {
+	attach: function(newFileMenu) {
+		const self = this
+		const document = Types.getFileType('document')
+		const spreadsheet = Types.getFileType('spreadsheet')
+		const presentation = Types.getFileType('presentation')
+
+		newFileMenu.addMenuEntry({
+			id: 'add-' + document.extension,
+			displayName: t('officeonline', 'New Document'),
+			templateName: t('officeonline', 'New Document') + '.' + document.extension,
+			iconClass: 'icon-filetype-document',
+			fileType: 'x-office-document',
+			actionHandler: function(filename) {
+				self._createDocument(document.mime, filename)
+			},
+		})
+
+		newFileMenu.addMenuEntry({
+			id: 'add-' + spreadsheet.extension,
+			displayName: t('officeonline', 'New Spreadsheet'),
+			templateName: t('officeonline', 'New Spreadsheet') + '.' + spreadsheet.extension,
+			iconClass: 'icon-filetype-spreadsheet',
+			fileType: 'x-office-spreadsheet',
+			actionHandler: function(filename) {
+				self._createDocument(spreadsheet.mime, filename)
+			},
+		})
+
+		newFileMenu.addMenuEntry({
+			id: 'add-' + presentation.extension,
+			displayName: t('officeonline', 'New Presentation'),
+			templateName: t('officeonline', 'New Presentation') + '.' + presentation.extension,
+			iconClass: 'icon-filetype-presentation',
+			fileType: 'x-office-presentation',
+			actionHandler: function(filename) {
+				self._createDocument(presentation.mime, filename)
+			},
+		})
+	},
+
+	_createDocument: function(mimetype, filename) {
+		const dir = document.getElementById('dir') ? document.getElementById('dir').value : window.FileList.getCurrentDirectory()
+		try {
+			OCA.Files.Files.isFileNameValid(filename)
+		} catch (e) {
+			window.OC.dialogs.alert(e, t('core', 'Could not create file'))
+			return
+		}
+		filename = FileList.getUniqueName(filename)
+		const path = dir + '/' + filename
+
+		const isPublic = document.getElementById('isPublic') ? document.getElementById('isPublic').value === '1' : false
+		if (isPublic) {
+			return window.FileList.createFile(filename).then(function() {
+				OCA.Viewer.open({ path })
+			})
+		}
+
+		axios.post(OC.generateUrl('apps/officeonline/ajax/documents/create'), { mimetype, filename, dir }).then(({ data }) => {
+			console.debug(data)
+			if (data && data.status === 'success') {
+				window.FileList.add(data.data, { animate: true, scrollTo: true })
+				window.OCA.Viewer.open({ path })
+			} else {
+				window.OC.dialogs.alert(data.data.message, t('core', 'Could not create file'))
+			}
+		})
+	},
+}
+
 document.addEventListener('DOMContentLoaded', () => {
 	// PUBLIC SHARE LINK HANDLING
 	const isPublic = document.getElementById('isPublic') ? document.getElementById('isPublic').value === '1' : false
@@ -29,4 +102,6 @@ document.addEventListener('DOMContentLoaded', () => {
 			render: h => h(Office, { props: { fileName: document.getElementById('filename').value } }),
 		}).$mount('#imgframe')
 	}
+
+	OC.Plugins.register('OCA.Files.NewFileMenu', NewFilePlugin)
 })


### PR DESCRIPTION
Apparently I cleaned up a bit too much when preparing the 28 compatibility as the new files menu is still needed for public share links