### PR TITLE
refactor: Migrate away from deprecated `ILogger` to PSR-3

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -18,7 +18,6 @@ use \OCP\AppFramework\Http\ContentSecurityPolicy;
 use \OCP\AppFramework\Http\TemplateResponse;
 use \OCP\IConfig;
 use \OCP\IL10N;
-use \OCP\ILogger;
 use \OCP\IRequest;
 use OC\Files\Type\TemplateManager;
 use OCA\Officeonline\Service\FederationService;
@@ -37,6 +36,7 @@ use OCP\Files\NotPermittedException;
 use OCP\ISession;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
+use Psr\Log\LoggerInterface;
 
 class DocumentController extends Controller {
 	/** @var string */
@@ -47,7 +47,7 @@ class DocumentController extends Controller {
 	private $settings;
 	/** @var AppConfig */
 	private $appConfig;
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 	/** @var IManager */
 	private $shareManager;
@@ -77,7 +77,7 @@ class DocumentController extends Controller {
 	 * @param IRootFolder $rootFolder
 	 * @param ISession $session
 	 * @param string $UserId
-	 * @param ILogger $logger
+	 * @param LoggerInterface $logger
 	 */
 	public function __construct(
 		$appName,
@@ -90,7 +90,7 @@ class DocumentController extends Controller {
 		IRootFolder $rootFolder,
 		ISession $session,
 		$UserId,
-		ILogger $logger,
+		LoggerInterface $logger,
 		\OCA\Officeonline\TemplateManager $templateManager,
 		FederationService $federationService,
 		Helper $helper
@@ -145,7 +145,7 @@ class DocumentController extends Controller {
 						'token' => $token
 					];
 				} catch (\Exception $e) {
-					$this->logger->logException($e, ['app' => 'officeonline']);
+					$this->logger->error($e->getMessage(), ['app' => 'officeonline', 'exception' => $e]);
 				}
 			}
 		}
@@ -199,7 +199,7 @@ class DocumentController extends Controller {
 				$this->logger->warning('Failed to connect to remote collabora instance for ' . $fileId);
 			}
 		} catch (\Exception $e) {
-			$this->logger->logException($e, ['app' => 'officeonline']);
+			$this->logger->error($e->getMessage(), ['app' => 'officeonline', 'exception' => $e]);
 			$params = [
 				'errors' => [['error' => $e->getMessage()]]
 			];
@@ -274,7 +274,7 @@ class DocumentController extends Controller {
 			$response->addHeader('Pragma', 'no-cache');
 			return $response;
 		} catch (\Exception $e) {
-			$this->logger->logException($e, ['app' => 'officeonline']);
+			$this->logger->error($e->getMessage(), ['app' => 'officeonline', 'exception' => $e]);
 			return $this->renderErrorPage('Failed to open the requested file.');
 		}
 
@@ -396,7 +396,7 @@ class DocumentController extends Controller {
 				return $response;
 			}
 		} catch (\Exception $e) {
-			$this->logger->logException($e, ['app' => 'officeonline']);
+			$this->logger->error($e->getMessage(), ['app' => 'officeonline', 'exception' => $e]);
 		}
 
 		return $this->renderErrorPage('Failed to open the requested file.');
@@ -467,7 +467,7 @@ class DocumentController extends Controller {
 		} catch (ShareNotFound $e) {
 			return new TemplateResponse('core', '404', [], 'guest');
 		} catch (\Exception $e) {
-			$this->logger->logException($e, ['app' => 'officeonline']);
+			$this->logger->error($e->getMessage(), ['app' => 'officeonline', 'exception' => $e]);
 			return $this->renderErrorPage('Failed to open the requested file.');
 		}
 

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -20,7 +20,7 @@ use OCA\Officeonline\WOPI\DiscoveryManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 class SettingsController extends Controller {
 
@@ -30,7 +30,7 @@ class SettingsController extends Controller {
 	private $appConfig;
 	/** @var DiscoveryManager  */
 	private $discoveryManager;
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 
 	public function __construct($appName,
@@ -38,7 +38,7 @@ class SettingsController extends Controller {
 		IL10N $l10n,
 		AppConfig $appConfig,
 		DiscoveryManager $discoveryManager,
-		ILogger $logger
+		LoggerInterface $logger
 	) {
 		parent::__construct($appName, $request);
 		$this->l10n = $l10n;
@@ -55,7 +55,7 @@ class SettingsController extends Controller {
 		try {
 			$response = $this->discoveryManager->fetchFromRemote();
 		} catch (Exception $e) {
-			$this->logger->logException($e, ['app' => 'officeonline']);
+			$this->logger->error('Could not fetch discovery details', ['app' => 'officeonline', 'exception' => $e]);
 			return new DataResponse([
 				'status' => $e->getCode(),
 				'message' => 'Could not fetch discovery details'

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -56,7 +56,6 @@ use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\IConfig;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
@@ -64,6 +63,7 @@ use OCP\Lock\LockedException;
 use OCP\PreConditionNotMetException;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
+use Psr\Log\LoggerInterface;
 
 class WopiController extends Controller {
 	/** @var IRootFolder */
@@ -80,7 +80,7 @@ class WopiController extends Controller {
 	private $userManager;
 	/** @var WopiMapper */
 	private $wopiMapper;
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 	/** @var TemplateManager */
 	private $templateManager;
@@ -118,7 +118,7 @@ class WopiController extends Controller {
 	 * @param TokenManager $tokenManager
 	 * @param IUserManager $userManager
 	 * @param WopiMapper $wopiMapper
-	 * @param ILogger $logger
+	 * @param LoggerInterface $logger
 	 * @param TemplateManager $templateManager
 	 * @param IManager $shareManager
 	 * @param UserScopeService $userScopeService
@@ -136,7 +136,7 @@ class WopiController extends Controller {
 		TokenManager $tokenManager,
 		IUserManager $userManager,
 		WopiMapper $wopiMapper,
-		ILogger $logger,
+		LoggerInterface $logger,
 		TemplateManager $templateManager,
 		IManager $shareManager,
 		UserScopeService $userScopeService,
@@ -200,7 +200,7 @@ class WopiController extends Controller {
 			$this->logger->debug($e->getMessage(), ['app' => 'officeonline', '']);
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		} catch (Exception $e) {
-			$this->logger->logException($e, ['app' => 'officeonline']);
+			$this->logger->error($e->getMessage(), ['app' => 'officeonline', 'exception' => $e]);
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 
@@ -329,7 +329,7 @@ class WopiController extends Controller {
 			$response->addHeader('Content-Type', 'application/octet-stream');
 			return $response;
 		} catch (Exception $e) {
-			$this->logger->logException($e, ['level' => ILogger::ERROR,	'app' => 'officeonline', 'message' => 'getFile failed']);
+			$this->logger->error('getFile failed', ['exception' => $e, 'app' => 'officeonline']);
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 	}
@@ -457,7 +457,7 @@ class WopiController extends Controller {
 			$response->setStatus(Http::STATUS_CONFLICT);
 			return $response;
 		} catch (Exception $e) {
-			$this->logger->logException($e);
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 	}
@@ -485,7 +485,7 @@ class WopiController extends Controller {
 		} catch (NoLockProviderException|PreConditionNotMetException $e) {
 			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
 		} catch (Exception $e) {
-			$this->logger->logException($e);
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 	}
@@ -509,7 +509,7 @@ class WopiController extends Controller {
 			$response->setStatus(Http::STATUS_CONFLICT);
 			return $response;
 		} catch (Exception $e) {
-			$this->logger->logException($e);
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 	}
@@ -616,7 +616,7 @@ class WopiController extends Controller {
 					});
 				});
 			} catch (LockedException $e) {
-				$this->logger->logException($e);
+				$this->logger->error($e->getMessage(), ['exception' => $e]);
 				return new JSONResponse(['message' => 'File locked'], Http::STATUS_INTERNAL_SERVER_ERROR);
 			}
 
@@ -636,7 +636,7 @@ class WopiController extends Controller {
 			}
 			return new JSONResponse(['LastModifiedTime' => Helper::toISO8601($file->getMTime())]);
 		} catch (Exception $e) {
-			$this->logger->logException($e, ['level' => ILogger::ERROR,	'app' => 'officeonline', 'message' => 'getFile failed']);
+			$this->logger->errpr('getFile failed', ['app' => 'officeonline', 'exception' => $e]);
 			return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 	}
@@ -839,7 +839,7 @@ class WopiController extends Controller {
 
 			return new JSONResponse([ 'Name' => $file->getName(), 'Url' => $url ], Http::STATUS_OK);
 		} catch (Exception $e) {
-			$this->logger->logException($e, ['level' => ILogger::ERROR,	'app' => 'officeonline', 'message' => 'putRelativeFile failed']);
+			$this->logger->error('putRelativeFile failed', ['app' => 'officeonline', 'exception' => $e]);
 			return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 	}
@@ -928,7 +928,7 @@ class WopiController extends Controller {
 			$response->addHeader('Content-Type', 'application/octet-stream');
 			return $response;
 		} catch (Exception $e) {
-			$this->logger->logException($e, ['level' => ILogger::ERROR,	'app' => 'officeonline', 'message' => 'getTemplate failed']);
+			$this->logger->error('getTemplate failed', ['app' => 'officeonline', 'exception' => $e]);
 			return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 	}

--- a/lib/Db/WopiMapper.php
+++ b/lib/Db/WopiMapper.php
@@ -26,8 +26,8 @@ use OCP\AppFramework\Db\QBMapper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
-use OCP\ILogger;
 use OCP\Security\ISecureRandom;
+use Psr\Log\LoggerInterface;
 
 class WopiMapper extends QBMapper {
 	// Tokens expire after this many seconds (not defined by WOPI specs).
@@ -36,7 +36,7 @@ class WopiMapper extends QBMapper {
 	/** @var ISecureRandom */
 	private $random;
 
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 
 	/** @var ITimeFactory */
@@ -44,7 +44,7 @@ class WopiMapper extends QBMapper {
 
 	public function __construct(IDBConnection $db,
 		ISecureRandom $random,
-		ILogger $logger,
+		LoggerInterface $logger,
 		ITimeFactory $timeFactory) {
 		parent::__construct($db, 'officeonline_wopi', Wopi::class);
 

--- a/lib/Hooks/WopiLockHooks.php
+++ b/lib/Hooks/WopiLockHooks.php
@@ -9,9 +9,9 @@ use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
-use OCP\ILogger;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
+use Psr\Log\LoggerInterface;
 
 class WopiLockHooks {
 	private $rootFolder;
@@ -29,11 +29,11 @@ class WopiLockHooks {
 	 */
 	private $lockBypass;
 	/**
-	 * @var ILogger
+	 * @var LoggerInterface
 	 */
 	private $logger;
 
-	public function __construct(IRootFolder $rootFolder, ITimeFactory $timeFactory, ILogger $logger, WopiLockMapper $lockMapper) {
+	public function __construct(IRootFolder $rootFolder, ITimeFactory $timeFactory, LoggerInterface $logger, WopiLockMapper $lockMapper) {
 		$this->rootFolder = $rootFolder;
 		$this->lockMapper = $lockMapper;
 		$this->timeFactory = $timeFactory;
@@ -59,11 +59,11 @@ class WopiLockHooks {
 					$node->lock(ILockingProvider::LOCK_SHARED);
 				}
 			} catch (InvalidPathException $e) {
-				$this->logger->logException($e);
+				$this->logger->error('Invalid path', ['exception' => $e]);
 			} catch (NotFoundException $e) {
-				$this->logger->debug('not a file');
+				$this->logger->debug('not a file', ['exception' => $e]);
 			} catch (LockedException $e) {
-				$this->logger->logException($e);
+				$this->logger->error('Node already locked', ['exception' => $e]);
 			}
 		}
 	}

--- a/lib/Preview/Office.php
+++ b/lib/Preview/Office.php
@@ -25,8 +25,8 @@ use OC\Preview\Provider;
 use OCA\Officeonline\Capabilities;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
-use OCP\ILogger;
 use OCP\Image;
+use Psr\Log\LoggerInterface;
 
 abstract class Office extends Provider {
 
@@ -39,10 +39,10 @@ abstract class Office extends Provider {
 	/** @var array */
 	private $capabilitites;
 
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 
-	public function __construct(IClientService $clientService, IConfig $config, Capabilities $capabilities, ILogger $logger) {
+	public function __construct(IClientService $clientService, IConfig $config, Capabilities $capabilities, LoggerInterface $logger) {
 		$this->clientService = $clientService;
 		$this->config = $config;
 		$this->capabilitites = $capabilities->getCapabilities()['officeonline'];
@@ -89,9 +89,8 @@ abstract class Office extends Provider {
 		try {
 			$response = $client->post($this->getWopiURL(). '/lool/convert-to/png', $options);
 		} catch (\Exception $e) {
-			$this->logger->logException($e, [
-				'message' => 'Failed to convert file to preview',
-				'level' => ILogger::INFO,
+			$this->logger->info('Failed to convert file to preview', [
+				'exception' => $e,
 				'app' => 'officeonline',
 			]);
 			return false;

--- a/lib/Service/FederationService.php
+++ b/lib/Service/FederationService.php
@@ -33,7 +33,7 @@ use OCP\Files\NotFoundException;
 use OCP\Http\Client\IClientService;
 use OCP\ICache;
 use OCP\ICacheFactory;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 class FederationService {
 
@@ -41,14 +41,14 @@ class FederationService {
 	private $cache;
 	/** @var IClientService */
 	private $clientService;
-	/** @var ILogger  */
+	/** @var LoggerInterface  */
 	private $logger;
 	/** @var TrustedServers */
 	private $trustedServers;
 	/** @var TokenManager */
 	private $tokenManager;
 
-	public function __construct(ICacheFactory $cacheFactory, IClientService $clientService, ILogger $logger, TokenManager $tokenManager) {
+	public function __construct(ICacheFactory $cacheFactory, IClientService $clientService, LoggerInterface $logger, TokenManager $tokenManager) {
 		$this->cache = $cacheFactory->createLocal('officeonline_remote/');
 		$this->clientService = $clientService;
 		$this->logger = $logger;


### PR DESCRIPTION
* Target version: main

### Summary
Mostly replace `ILogger` with `LoggerInterface` and some minor cleanup (constructor property promotion).

Some places used the deprecated `logException`, this is easy to migrate: Simply use the appropriate log level on the logger and place the exception under the `exception` key in the context.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
