### PR TITLE
fix: add clarifying use case details to appstore

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,8 @@
 
 	**Note: The cloud-based Office 365 is not supported.**
 		
-	Microsoft Official Documentation: [Deploying Office Online Server](https://docs.microsoft.com/en-us/officeonlineserver/deploy-office-online-server)]]</description>
+	Microsoft Official Documentation: [Deploying Office Online Server](https://docs.microsoft.com/en-us/officeonlineserver/deploy-office-online-server)]]>
+	</description>
 
 	<version>3.0.0-dev.0</version>
 	<licence>agpl</licence>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -3,7 +3,11 @@
 	<id>officeonline</id>
 	<name>Office Online integration</name>
 	<summary>Edit office documents directly in your browser.</summary>
-	<description>This application can connect to an Office Online server with Nextcloud.</description>
+	<description><![CDATA[This application can connect to an on-premise/self-hosted Microsoft Office Online Server which has added Nextcloud as a WOPI host.
+
+	**Note: The cloud-based Office 365 is not supported.**
+		
+	Microsoft Official Documentation: [Deploying Office Online Server](https://docs.microsoft.com/en-us/officeonlineserver/deploy-office-online-server)]]</description>
 
 	<version>3.0.0-dev.0</version>
 	<licence>agpl</licence>


### PR DESCRIPTION
* Target version: main

### Summary

Add a tiny bit more info to the app store description so that:

- it's not confused with Nextcloud Office or CODE
- it's clearer it works with Office Online Server (self-hosted) not cloud

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
