### PR TITLE
fix: Properly create new files on public share links

### DIFF
--- a/lib/WOPI/Parser.php
+++ b/lib/WOPI/Parser.php
@@ -188,7 +188,7 @@ class Parser {
 		}
 
 		$actions = [
-			$edit && $file->getSize() === 0 ? self::ACTION_EDITNEW : null,
+			$edit && ($file->getSize() === 0 || $file->getSize() === 1) ? self::ACTION_EDITNEW : null,
 			$edit ? self::ACTION_EDIT : null,
 			self::ACTION_VIEW,
 		];


### PR DESCRIPTION
Office online creates new files through a separate `editnew` endpoint. We choose that by detecting that the file is empty. Now it seems that with public share links new files created through the web ui are created as 1 byte files instead of 0 bytes (reason to be found out separately in the files frontend code).

This PR should fix creating new files on public share links for 28/29 (likely also 27).