### PR TITLE
chore: Switch to new API to set volatile user to prevent persisting it in any case

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -295,8 +295,7 @@ class WopiController extends Controller {
 
 		try {
 			/** @var File $file */
-			$userFolder = $this->rootFolder->getUserFolder($wopi->getOwnerUid());
-			$file = $userFolder->getById($fileId)[0];
+			$file = $this->getFileForWopiToken($wopi);
 			\OC_User::setIncognitoMode(true);
 			if ($version !== '0') {
 				$view = new View('/' . $wopi->getOwnerUid() . '/files');

--- a/lib/Service/UserScopeService.php
+++ b/lib/Service/UserScopeService.php
@@ -31,7 +31,12 @@ class UserScopeService {
 		if ($user === null) {
 			throw new \InvalidArgumentException('No user found for the uid ' . $uid);
 		}
-		$this->userSession->setUser($user);
+
+		if (method_exists($this->userSession, 'setVolatileActiveUser')) {
+			$this->userSession->setVolatileActiveUser($user);
+		} else {
+			$this->userSession->setUser($user);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Mostly cherry-picking changes from richdocuments https://github.com/nextcloud/richdocuments/pull/3833 

Making use of https://github.com/nextcloud/server/pull/44295

Steps to reproduce:
- Have a groupfolder with ACL limited to block sharing
- Try to open the file with officeonline (also works with a collabora instance)