### PR TITLE
fix: Always lookup lower case file extensions

### DIFF
--- a/lib/WOPI/Parser.php
+++ b/lib/WOPI/Parser.php
@@ -199,6 +199,7 @@ class Parser {
 	}
 
 	private function getUrlSrcByExtension(string $netZoneName, string $actionExt, $actionName): ?string {
+		$actionExt = strtolower($actionExt);
 		$result = $this->getParsed()->xpath(sprintf(
 			'/wopi-discovery/net-zone[@name=\'%s\']/app/action[@ext=\'%s\' and @name=\'%s\']',
 			$netZoneName, $actionExt, $actionName


### PR DESCRIPTION
Fix #599

Otherwise files with uppercase extensions can not be matched in the discovery response. For Collabora this works becaues we do a match by mimetype there, just with office online only extensions are exposed.