### PR TITLE
chore(release): Bump version to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 -->
 # Changelog
 
+## 3.1.0
+
+### Added
+
+- Support NC 31, drop 24,25 and with it PHP <8.0 support @blizzz [#610](https://github.com/nextcloud/officeonline/pull/610)
+
+### Fix
+
+- fix(GS): consolidate and extend CSP management @blizzz [#559](https://github.com/nextcloud/officeonline/pull/559)
+- fix: WopiLock is not 31 compatible @blizzz [#611](https://github.com/nextcloud/officeonline/pull/611)
+
 ## 2.3.2
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
 	Microsoft Official Documentation: [Deploying Office Online Server](https://docs.microsoft.com/en-us/officeonlineserver/deploy-office-online-server)]]>
 	</description>
 
-	<version>3.1.0-dev.0</version>
+	<version>3.1.0</version>
 	<licence>agpl</licence>
 
 	<author>Julius Härtl</author>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "officeonline",
   "description": "Collabora online integration",
-  "version": "3.1.0-dev.0",
+  "version": "3.1.0",
   "authors": [
     {
       "name": "Julius Härtl",


### PR DESCRIPTION
## Changelog

```
## 3.1.0

### Added

- Support NC 31, drop 24,25 and with it PHP <8.0 support @blizzz [#610](https://github.com/nextcloud/officeonline/pull/610)

### Fix

- fix(GS): consolidate and extend CSP management @blizzz [#559](https://github.com/nextcloud/officeonline/pull/559)
- fix: WopiLock is not 31 compatible @blizzz [#611](https://github.com/nextcloud/officeonline/pull/611)