### PR TITLE
fix: Avoid failures with share tokens used as user ids for remote instances

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -538,8 +538,10 @@ class WopiController extends Controller {
 		}
 
 		// Set the user to register the change under his name
-		$this->userScopeService->setUserScope($wopi->getEditorUid());
-		$this->userScopeService->setFilesystemScope($wopi->getUserForFileAccess());
+		if (empty($wopi->getRemoteServer())) {
+			$this->userScopeService->setUserScope($wopi->getEditorUid());
+			$this->userScopeService->setFilesystemScope($wopi->getUserForFileAccess());
+		}
 
 		try {
 			if ($isPutRelative) {
@@ -587,7 +589,9 @@ class WopiController extends Controller {
 			$content = fopen('php://input', 'rb');
 
 			// Set the user to register the change under his name
-			$this->userScopeService->setUserScope($wopi->getEditorUid());
+			if (empty($wopi->getRemoteServer())) {
+				$this->userScopeService->setUserScope($wopi->getEditorUid());
+			}
 			$this->lockHooks->setLockBypass(true);
 
 			try {
@@ -803,8 +807,10 @@ class WopiController extends Controller {
 
 			$content = fopen('php://input', 'rb');
 			// Set the user to register the change under his name
-			$this->userScopeService->setUserScope($wopi->getEditorUid());
-			$this->userScopeService->setFilesystemScope($wopi->getEditorUid());
+			if (empty($wopi->getRemoteServer())) {
+				$this->userScopeService->setUserScope($wopi->getEditorUid());
+				$this->userScopeService->setFilesystemScope($wopi->getEditorUid());
+			}
 
 			$this->lockHooks->setLockBypass(true);
 			try {


### PR DESCRIPTION
* Target version: main

### Summary

Fixes an `InvalidArgumentException` with  `No user found for the uid user123`  on saving files as a federated user. 

### Checklist

- [X] Code is properly formatted
- [X] Sign-off message is added to all commits
- [X] Documentation (manuals or wiki) has been updated or is not required
