### PR TITLE
fix: url encode file name

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -237,7 +237,11 @@ class DocumentController extends Controller {
 			[$urlSrc, $token] = $this->tokenManager->getToken($item->getId());
 			$params = [
 				'permissions' => $item->getPermissions(),
-				'title' => $item->getName(),
+
+				// The file name needs to be URL encoded else special characters
+				// cause problems when the server parses/validates the URL
+				'title' => urlencode($item->getName()),
+
 				'fileId' => $item->getId() . '_' . $this->settings->getSystemValue('instanceid'),
 				'token' => $token,
 				'urlsrc' => $urlSrc,


### PR DESCRIPTION
* Target version: main

### Summary
Fixes the issue that spreadsheets will not open if there is an apostrophe or other unexpected symbol in the file's name. It simply should be URL encoded so that when it is passed to the `documents.php` template, it can be requested properly.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
