### PR TITLE
fix: use isset to check token and urlsrc

### DIFF
--- a/templates/documents.php
+++ b/templates/documents.php
@@ -9,8 +9,8 @@
 	var officeonline_permissions = '<?php p($_['permissions']) ?>';
 	var officeonline_title = '<?php p($_['title']) ?>';
 	var officeonline_fileId = '<?php p($_['fileId']) ?>';
-	var officeonline_token = '<?php p($_['token'] ? $_['token'] : "''") ?>';
-	var officeonline_urlsrc = '<?php p($_['urlsrc'] ? $_['urlsrc'] : "''") ?>';
+	var officeonline_token = '<?php p(isset($_['token']) ? $_['token'] : "''") ?>';
+	var officeonline_urlsrc = '<?php p(isset($_['urlsrc']) ? $_['urlsrc'] : "''") ?>';
 	var officeonline_path = '<?php p($_['path']) ?>';
 	var officeonline_userId = <?php isset($_['userId']) ? print_unescaped('\'' . \OCP\Util::sanitizeHTML($_['userId']) . '\'') : print_unescaped('null') ?>;
 	var officeonline_instanceId = '<?php p($_['instanceId']) ?>';


### PR DESCRIPTION
* ~~Resolves: # <!-- related github issue -->~~
* Target version: main

### Summary
Use isset to check for `token` and `urlsrc` to prevent crashes when they aren't set

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
